### PR TITLE
docs: improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ This is helpful in cases when you need to allow HTTPS interception for tools lik
 
 ## Usage
 
-```js
+```json
 {
-  plugins: [
+  "plugins": [
     [
-      'expo-network-security-config',
+      "expo-network-security-config",
       {
-        networkSecurityConfig: './assets/configs/network_security_config.xml',
-        enable: true,
-      },
-    ],
-  ];
+        "networkSecurityConfig": "./assets/configs/network_security_config.xml",
+        "enable": true
+      }
+    ]
+  ]
 }
 ```
 
-## Example Config
+### Example Config
 
 The following example allows [Proxyman](https://proxyman.io/) to intercept HTTP/HTTPS requests by trusting user-added CAs:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Expo Network Security Config
 
-This [Expo config plugin](https://docs.expo.dev/config-plugins/introduction/) allows you to include a [network security config](https://developer.android.com/privacy-and-security/security-config) within your app.
-This is helpful in cases when you need to allow HTTPS interception for tools like [Proxyman](https://developer.android.com/privacy-and-security/security-config) in your Android app.
+An [Expo config plugin](https://docs.expo.dev/config-plugins/introduction/) that copies a custom [network security config](https://developer.android.com/privacy-and-security/security-config) into your Android app.
+This is useful when you need to allow HTTPS interception for tools like [Proxyman](https://proxyman.io/) on Android.
 
 ### Platform Compatibility
 
@@ -9,7 +9,19 @@ This is helpful in cases when you need to allow HTTPS interception for tools lik
 | -------------- | ---------------- | ---------- | ------------- | --- |
 | ✅             | ✅               | ❌         | ❌            | ❌  |
 
+## Installation
+
+```sh
+npx expo install expo-network-security-config
+```
+
+Requires **Expo SDK 50+**.
+
 ## Usage
+
+1. Create your `network_security_config.xml` file somewhere in your project (e.g. `assets/configs/network_security_config.xml`).
+
+2. Add the plugin to the `plugins` array in your `app.json` (or `app.config.js`):
 
 ```json
 {
@@ -24,6 +36,14 @@ This is helpful in cases when you need to allow HTTPS interception for tools lik
   ]
 }
 ```
+
+3. Run prebuild to regenerate the native project:
+
+```sh
+npx expo prebuild
+```
+
+The plugin copies your XML file into `android/app/src/main/res/xml/` and adds `android:networkSecurityConfig` to `AndroidManifest.xml`.
 
 ### Example Config
 
@@ -50,7 +70,7 @@ The following example allows [Proxyman](https://proxyman.io/) to intercept HTTP/
 
 ## API
 
-| Parameter             | Description                         |
-| --------------------- | ----------------------------------- |
-| networkSecurityConfig | Path to network_security_config.xml |
-| enable                | Enable or disable this config       |
+| Parameter               | Description                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------ |
+| `networkSecurityConfig` | Path to your `network_security_config.xml` file, relative to the project root.                   |
+| `enable`                | When `true`, the config is copied and applied. When `false` (or omitted), the plugin is skipped. |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ This is helpful in cases when you need to allow HTTPS interception for tools lik
 }
 ```
 
+## Example Config
+
+The following example allows [Proxyman](https://proxyman.io/) to intercept HTTP/HTTPS requests by trusting user-added CAs:
+
+```xml
+<network-security-config>
+  <debug-overrides>
+    <trust-anchors>
+      <!-- Trust user added CAs while debuggable only -->
+      <certificates src="user" />
+      <certificates src="system" />
+    </trust-anchors>
+  </debug-overrides>
+
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <certificates src="system" />
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>
+```
+
 ## API
 
 | Parameter             | Description                         |


### PR DESCRIPTION
## Summary

Adds an example config section to the README showing how to configure `network_security_config.xml` so Proxyman can intercept HTTP/HTTPS requests on Android. The config trusts user-added CAs in both `debug-overrides` and `base-config`, and permits cleartext traffic.

## What changed

- Added "Example Config" section to README with a ready-to-use XML snippet